### PR TITLE
feat: add ability to handle upgrade from http to websocket connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ import { Synapse, Terminal } from "@appwrite.io/synapse";
 const synapse = new Synapse("localhost", 8080);
 
 // Connect to WebSocket server
-await synapse.connect("/terminal");
+await synapse.connect("/");
 
 // Create terminal instance with Synapse
 const terminal = new Terminal(synapse);

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ npm install @appwrite.io/synapse
 import { Synapse, Terminal } from "@appwrite.io/synapse";
 
 // Initialize Synapse for WebSocket communication
-const synapse = new Synapse();
+const synapse = new Synapse("localhost", 8080);
 
 // Connect to WebSocket server
-await synapse.connect("ws://your-server-url");
+await synapse.connect("/terminal");
 
 // Create terminal instance with Synapse
 const terminal = new Terminal(synapse);

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ Operating system gateway for remote serverless environments. Synapse provides a 
   - Commit and push changes
   - Pull and merge remote changes
 
+- 📝 Code Style Management
+
+  - Linting and formatting
+  - Error detection and correction
+  - Code formatting options
+
 ## Installation
 
 ```bash
@@ -125,6 +131,43 @@ await git.commit("feat: add new features");
 // Pull and push changes
 await git.pull();
 await git.push();
+```
+
+### Code Style Management
+
+```typescript
+// Lint and format code
+import { Synapse, CodeStyle } from "@appwrite.io/synapse";
+
+const synapse = new Synapse();
+const codeStyle = new CodeStyle(synapse);
+
+// Format code with specific options
+const code = `function hello(name) {
+return "Hello, " + name;
+}`;
+
+const formatResult = await codeStyle.format(code, {
+  language: "javascript",
+  indent: 2,
+  singleQuote: true,
+  semi: true,
+});
+
+console.log("Formatted code:", formatResult.data);
+
+// Lint code for potential issues
+const lintResult = await codeStyle.lint(code, {
+  language: "javascript",
+  rules: {
+    semi: "error",
+    "no-unused-vars": "warn",
+  },
+});
+
+if (lintResult.issues.length > 0) {
+  console.log("Linting issues found:", lintResult.issues);
+}
 ```
 
 ### Event Handling

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   ],
   "scripts": {
     "build": "tsup",
-    "test": "jest",
-    "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage",
+    "test": "node --no-warnings --experimental-vm-modules node_modules/.bin/jest",
+    "test:watch": "node --no-warnings --experimental-vm-modules node_modules/.bin/jest --watch",
+    "test:coverage": "node --no-warnings --experimental-vm-modules node_modules/.bin/jest --coverage",
     "lint": "eslint src/**/*.ts",
     "format": "prettier --write .",
     "prepare": "npm run build"
@@ -23,7 +23,9 @@
   "license": "MIT",
   "dependencies": {
     "node-pty": "^1.0.0",
-    "ws": "^8.18.1"
+    "ws": "^8.18.1",
+    "eslint": "^9.23.0",
+    "prettier": "^3.5.3"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
@@ -31,11 +33,9 @@
     "@types/ws": "^8.18.0",
     "@typescript-eslint/eslint-plugin": "^8.28.0",
     "@typescript-eslint/parser": "^8.28.0",
-    "esbuild": "^0.25.1",
+    "esbuild": "^0.25.2",
     "esbuild-plugin-file-path-extensions": "^2.1.4",
-    "eslint": "^9.23.0",
     "jest": "^29.7.0",
-    "prettier": "^3.5.3",
     "ts-jest": "^29.3.0",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export { CodeStyle } from "./services/codestyle";
 export { Filesystem } from "./services/filesystem";
 export { Git } from "./services/git";
 export { System } from "./services/system";

--- a/src/services/codestyle.ts
+++ b/src/services/codestyle.ts
@@ -1,0 +1,123 @@
+import { ESLint } from "eslint";
+import { format, Options } from "prettier";
+import { Synapse } from "../synapse";
+
+export interface FormatOptions {
+  language: string;
+  indent?: number;
+  useTabs?: boolean;
+  semi?: boolean;
+  singleQuote?: boolean;
+  printWidth?: number;
+}
+
+export interface LintOptions {
+  language: string;
+  rules?: Record<string, "error" | "warn" | "off">;
+}
+
+export interface FormatResult {
+  success: boolean;
+  data: string;
+}
+
+export interface LintResult {
+  success: boolean;
+  issues: Array<{
+    line: number;
+    column: number;
+    severity: "error" | "warning";
+    rule: string;
+    message: string;
+  }>;
+}
+
+export class CodeStyle {
+  private synapse: Synapse;
+
+  /**
+   * Creates a new CodeStyle instance
+   * @param synapse The Synapse instance for WebSocket communication
+   */
+  constructor(synapse: Synapse) {
+    this.synapse = synapse;
+  }
+
+  private getParserForLanguage(language: string): string {
+    const languageMap: Record<string, string> = {
+      javascript: "babel",
+      typescript: "typescript",
+      json: "json",
+      html: "html",
+      css: "css",
+      markdown: "markdown",
+      yaml: "yaml",
+    };
+
+    return languageMap[language.toLowerCase()] || "babel";
+  }
+
+  private toPrettierOptions(
+    language: string,
+    options?: FormatOptions,
+  ): Options {
+    const parser = this.getParserForLanguage(language);
+
+    return {
+      parser,
+      tabWidth: options?.indent || 2,
+      useTabs: options?.useTabs || false,
+      semi: options?.semi !== undefined ? options.semi : true,
+      singleQuote: options?.singleQuote || false,
+      printWidth: options?.printWidth || 80,
+    };
+  }
+
+  /**
+   * Format code according to specified options
+   * @param code The code to format
+   * @param options Formatting options
+   * @returns A promise resolving to the formatting result
+   */
+  async format(code: string, options: FormatOptions): Promise<FormatResult> {
+    const prettierOptions = this.toPrettierOptions(options.language, options);
+    const formattedCode = await format(code, prettierOptions);
+
+    return {
+      success: true,
+      data: formattedCode,
+    };
+  }
+
+  /**
+   * Lint code to identify issues
+   * @param code The code to lint
+   * @param options Linting options
+   * @returns A promise resolving to the linting result
+   */
+  async lint(code: string, options: LintOptions): Promise<LintResult> {
+    const eslintOptions = {
+      useEslintrc: false,
+      overrideConfig: {
+        parser: "@typescript-eslint/parser",
+        rules: options.rules || {},
+      },
+    };
+
+    const linter = new ESLint(eslintOptions);
+    const eslintResult = await linter.lintText(code);
+
+    return {
+      success: true,
+      issues: eslintResult.flatMap((result) =>
+        result.messages.map((message) => ({
+          line: message.line,
+          column: message.column,
+          severity: message.severity === 2 ? "error" : "warning",
+          rule: message.ruleId || "",
+          message: message.message,
+        })),
+      ),
+    };
+  }
+}

--- a/src/synapse.ts
+++ b/src/synapse.ts
@@ -107,7 +107,14 @@ class Synapse {
 
   private handleMessage(event: WebSocket.MessageEvent): void {
     try {
-      const message: MessagePayload = JSON.parse(event.data as string);
+      const data = event.data as string;
+
+      if (data === "ping" && this.ws) {
+        this.ws.send("pong");
+        return;
+      }
+
+      const message: MessagePayload = JSON.parse(data);
 
       if (this.messageHandlers[message.type]) {
         this.messageHandlers[message.type](message);
@@ -127,7 +134,7 @@ class Synapse {
 
   /**
    * Establishes a WebSocket connection to the specified URL and initializes the terminal
-   * @param path - The WebSocket endpoint path (e.g. '/terminal')
+   * @param path - The WebSocket endpoint path (e.g. '/' or '/terminal')
    * @returns Promise that resolves with the Synapse instance when connected
    * @throws Error if WebSocket connection fails
    */

--- a/tests/services/codestyle.test.ts
+++ b/tests/services/codestyle.test.ts
@@ -1,0 +1,234 @@
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import { ESLint } from "eslint";
+import { format } from "prettier";
+import { CodeStyle } from "../../src/services/codestyle";
+import { Synapse } from "../../src/synapse";
+
+jest.mock("prettier");
+jest.mock("eslint");
+jest.mock("../../src/synapse");
+
+describe("CodeStyle", () => {
+  let codeStyle: CodeStyle;
+  let mockSynapse: jest.Mocked<Synapse>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockSynapse = new Synapse() as jest.Mocked<Synapse>;
+    codeStyle = new CodeStyle(mockSynapse);
+  });
+
+  describe("format", () => {
+    test("should format JavaScript code with default options", async () => {
+      const input = "const x=1;const y=2;";
+      const expected = "const x = 1;\nconst y = 2;\n";
+
+      const mockFormat = format as jest.MockedFunction<typeof format>;
+      mockFormat.mockResolvedValue(expected);
+
+      const result = await codeStyle.format(input, { language: "javascript" });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(expected);
+      expect(format).toHaveBeenCalledWith(input, {
+        parser: "babel",
+        tabWidth: 2,
+        useTabs: false,
+        semi: true,
+        singleQuote: false,
+        printWidth: 80,
+      });
+    });
+
+    test("should format TypeScript code with custom options", async () => {
+      const input = 'const x:number=1;const y:string="test";';
+      const expected = "const x: number = 1\nconst y: string = 'test'\n";
+
+      const mockFormat = format as jest.MockedFunction<typeof format>;
+      mockFormat.mockResolvedValue(expected);
+
+      const result = await codeStyle.format(input, {
+        language: "typescript",
+        indent: 4,
+        useTabs: true,
+        semi: false,
+        singleQuote: true,
+        printWidth: 100,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(expected);
+      expect(format).toHaveBeenCalledWith(input, {
+        parser: "typescript",
+        tabWidth: 4,
+        useTabs: true,
+        semi: false,
+        singleQuote: true,
+        printWidth: 100,
+      });
+    });
+
+    test("should handle unsupported language gracefully", async () => {
+      const input = "some code";
+      const expected = "formatted code";
+
+      const mockFormat = format as jest.MockedFunction<typeof format>;
+      mockFormat.mockResolvedValue(expected);
+
+      const result = await codeStyle.format(input, { language: "unsupported" });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(expected);
+      expect(format).toHaveBeenCalledWith(input, {
+        parser: "babel", // Should default to babel
+        tabWidth: 2,
+        useTabs: false,
+        semi: true,
+        singleQuote: false,
+        printWidth: 80,
+      });
+    });
+  });
+
+  describe("lint", () => {
+    test("should lint JavaScript code with default rules", async () => {
+      const input = "const x = 1;\nconst y = 2;";
+      const mockLintResult: ESLint.LintResult[] = [
+        {
+          messages: [
+            {
+              line: 1,
+              column: 1,
+              severity: 2,
+              ruleId: "no-unused-vars",
+              message: "x is defined but never used",
+            },
+          ],
+          filePath: "",
+          errorCount: 1,
+          warningCount: 0,
+          fixableErrorCount: 0,
+          fixableWarningCount: 0,
+          source: input,
+          suppressedMessages: [],
+          fatalErrorCount: 0,
+          usedDeprecatedRules: [],
+        },
+      ];
+
+      const mockLintText = jest
+        .fn<() => Promise<ESLint.LintResult[]>>()
+        .mockResolvedValue(mockLintResult);
+      const MockESLint = jest.fn().mockImplementation(() => ({
+        lintText: mockLintText,
+      }));
+      (ESLint as unknown) = MockESLint;
+
+      const result = await codeStyle.lint(input, { language: "javascript" });
+
+      expect(result.success).toBe(true);
+      expect(result.issues).toHaveLength(1);
+      expect(result.issues[0]).toEqual({
+        line: 1,
+        column: 1,
+        severity: "error",
+        rule: "no-unused-vars",
+        message: "x is defined but never used",
+      });
+    });
+
+    test("should lint with custom rules", async () => {
+      const input = "let x = 1;";
+      const customRules = {
+        "prefer-const": "error" as const,
+      };
+
+      const mockLintResult: ESLint.LintResult[] = [
+        {
+          messages: [
+            {
+              line: 1,
+              column: 1,
+              severity: 2,
+              ruleId: "prefer-const",
+              message: "Use const instead of let",
+            },
+          ],
+          filePath: "",
+          errorCount: 1,
+          warningCount: 0,
+          fixableErrorCount: 0,
+          fixableWarningCount: 0,
+          source: input,
+          suppressedMessages: [],
+          fatalErrorCount: 0,
+          usedDeprecatedRules: [],
+        },
+      ];
+
+      const mockLintText = jest
+        .fn<() => Promise<ESLint.LintResult[]>>()
+        .mockResolvedValue(mockLintResult);
+      const MockESLint = jest.fn().mockImplementation(() => ({
+        lintText: mockLintText,
+      }));
+      (ESLint as unknown) = MockESLint;
+
+      const result = await codeStyle.lint(input, {
+        language: "javascript",
+        rules: customRules,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.issues).toHaveLength(1);
+      expect(result.issues[0].rule).toBe("prefer-const");
+      expect(MockESLint).toHaveBeenCalledWith({
+        useEslintrc: false,
+        overrideConfig: {
+          parser: "@typescript-eslint/parser",
+          rules: customRules,
+        },
+      });
+    });
+
+    test("should handle warnings correctly", async () => {
+      const input = 'console.log("test");';
+      const mockLintResult: ESLint.LintResult[] = [
+        {
+          messages: [
+            {
+              line: 1,
+              column: 1,
+              severity: 1, // Warning severity
+              ruleId: "no-console",
+              message: "Unexpected console statement",
+            },
+          ],
+          filePath: "",
+          errorCount: 0,
+          warningCount: 1,
+          fixableErrorCount: 0,
+          fixableWarningCount: 0,
+          source: input,
+          suppressedMessages: [],
+          fatalErrorCount: 0,
+          usedDeprecatedRules: [],
+        },
+      ];
+
+      const mockLintText = jest
+        .fn<() => Promise<ESLint.LintResult[]>>()
+        .mockResolvedValue(mockLintResult);
+      const MockESLint = jest.fn().mockImplementation(() => ({
+        lintText: mockLintText,
+      }));
+      (ESLint as unknown) = MockESLint;
+
+      const result = await codeStyle.lint(input, { language: "javascript" });
+
+      expect(result.success).toBe(true);
+      expect(result.issues[0].severity).toBe("warning");
+    });
+  });
+});

--- a/tests/synapse.test.ts
+++ b/tests/synapse.test.ts
@@ -12,6 +12,7 @@ const createMockWebSocket = (options: { readyState?: number } = {}) => ({
   onclose: null as unknown as (event: WebSocket.CloseEvent) => void,
   readyState: options.readyState ?? WebSocket.OPEN,
   send: jest.fn(),
+  close: jest.fn(),
 });
 
 describe("Synapse", () => {
@@ -20,6 +21,15 @@ describe("Synapse", () => {
   beforeEach(() => {
     synapse = new Synapse("localhost", 8080);
     jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    synapse.disconnect();
+    jest.clearAllTimers();
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
   });
 
   describe("connect", () => {
@@ -207,6 +217,7 @@ describe("Synapse", () => {
             callback(mockWs);
           }
         }),
+        close: jest.fn(),
       } as unknown as WebSocketServer;
 
       jest.mocked(WebSocketServer).mockImplementation(() => mockWss);
@@ -248,6 +259,7 @@ describe("Synapse", () => {
         handleUpgrade: mockHandleUpgrade,
         emit: mockEmit,
         on: jest.fn(),
+        close: jest.fn(),
       } as unknown as WebSocketServer;
 
       jest.mocked(WebSocketServer).mockImplementation(() => mockWss);

--- a/tests/synapse.test.ts
+++ b/tests/synapse.test.ts
@@ -1,4 +1,6 @@
-import WebSocket from "ws";
+import { IncomingMessage } from "http";
+import { Socket } from "net";
+import WebSocket, { WebSocketServer } from "ws";
 import { Synapse } from "../src/synapse";
 
 jest.mock("ws");
@@ -7,7 +9,7 @@ describe("Synapse", () => {
   let synapse: Synapse;
 
   beforeEach(() => {
-    synapse = new Synapse();
+    synapse = new Synapse("localhost", 8080);
     jest.clearAllMocks();
   });
 
@@ -24,10 +26,31 @@ describe("Synapse", () => {
 
       (WebSocket as unknown as jest.Mock).mockImplementation(() => mockWs);
 
-      const connectPromise = synapse.connect("ws://localhost:8080");
+      const connectPromise = synapse.connect("/terminal");
       mockWs.onopen!({} as WebSocket.Event);
 
       await expect(connectPromise).resolves.toBe(synapse);
+      expect(WebSocket).toHaveBeenCalledWith("ws://localhost:8080/terminal");
+    });
+
+    it("should use default host and port when not provided", async () => {
+      const defaultSynapse = new Synapse();
+      const mockWs = {
+        onopen: null as unknown as (event: WebSocket.Event) => void,
+        onmessage: null as unknown as (event: WebSocket.MessageEvent) => void,
+        onerror: null as unknown as (event: WebSocket.ErrorEvent) => void,
+        onclose: null as unknown as (event: WebSocket.CloseEvent) => void,
+        readyState: WebSocket.OPEN,
+        send: jest.fn(),
+      };
+
+      (WebSocket as unknown as jest.Mock).mockImplementation(() => mockWs);
+
+      const connectPromise = defaultSynapse.connect("/terminal");
+      mockWs.onopen!({} as WebSocket.Event);
+
+      await expect(connectPromise).resolves.toBe(defaultSynapse);
+      expect(WebSocket).toHaveBeenCalledWith("ws://localhost:3000/terminal");
     });
 
     it("should reject on connection error", async () => {
@@ -40,7 +63,7 @@ describe("Synapse", () => {
 
       (WebSocket as unknown as jest.Mock).mockImplementation(() => mockWs);
 
-      const connectPromise = synapse.connect("ws://localhost:8080");
+      const connectPromise = synapse.connect("/terminal");
       mockWs.onerror!({
         error: new Error("Connection failed"),
       } as WebSocket.ErrorEvent);
@@ -64,7 +87,7 @@ describe("Synapse", () => {
       };
 
       (WebSocket as unknown as jest.Mock).mockImplementation(() => mockWs);
-      const connectPromise = synapse.connect("ws://localhost:8080");
+      const connectPromise = synapse.connect("/terminal");
       mockWs.onopen!({} as WebSocket.Event);
       await connectPromise;
 
@@ -103,7 +126,7 @@ describe("Synapse", () => {
       };
 
       (WebSocket as unknown as jest.Mock).mockImplementation(() => mockWs);
-      const connectPromise = synapse.connect("ws://localhost:8080");
+      const connectPromise = synapse.connect("/terminal");
       mockWs.onopen!({} as WebSocket.Event);
       await connectPromise;
 
@@ -130,7 +153,7 @@ describe("Synapse", () => {
       };
 
       (WebSocket as unknown as jest.Mock).mockImplementation(() => mockWs);
-      const connectPromise = synapse.connect("ws://localhost:8080");
+      const connectPromise = synapse.connect("/terminal");
       mockWs.onopen!({} as WebSocket.Event);
       await connectPromise;
 
@@ -154,7 +177,7 @@ describe("Synapse", () => {
       };
 
       (WebSocket as unknown as jest.Mock).mockImplementation(() => mockWs);
-      const connectPromise = synapse.connect("ws://localhost:8080");
+      const connectPromise = synapse.connect("/terminal");
       mockWs.onopen!({} as WebSocket.Event);
       await connectPromise;
 
@@ -192,12 +215,120 @@ describe("Synapse", () => {
       };
 
       (WebSocket as unknown as jest.Mock).mockImplementation(() => mockWs);
-      const connectPromise = synapse.connect("ws://localhost:8080");
+      const connectPromise = synapse.connect("/terminal");
       mockWs.onopen!({} as WebSocket.Event);
       await connectPromise;
 
       expect(() => synapse.send("test-type")).toThrow(
         "WebSocket is not connected",
+      );
+    });
+  });
+
+  describe("handleUpgrade", () => {
+    it("should handle upgrade requests and establish WebSocket connection", () => {
+      const mockReq = {
+        headers: {
+          upgrade: "websocket",
+        },
+      } as IncomingMessage;
+
+      const mockSocket = {} as Socket;
+      const mockHead = Buffer.alloc(0);
+      const mockWs = {
+        on: jest.fn(),
+        onmessage: null as unknown as (event: WebSocket.MessageEvent) => void,
+        onclose: null as unknown as (event: WebSocket.CloseEvent) => void,
+        onerror: null as unknown as (event: WebSocket.ErrorEvent) => void,
+        readyState: WebSocket.OPEN,
+        send: jest.fn(),
+      } as unknown as WebSocket;
+
+      const mockHandleUpgrade = jest.fn((req, socket, head, cb) => {
+        cb(mockWs);
+      });
+      const mockEmit = jest.fn();
+
+      const mockWss = {
+        handleUpgrade: mockHandleUpgrade,
+        emit: mockEmit,
+        on: jest.fn((event, callback) => {
+          if (event === "connection") {
+            callback(mockWs);
+          }
+        }),
+      } as unknown as WebSocketServer;
+
+      jest.mocked(WebSocketServer).mockImplementation(() => mockWss);
+
+      synapse = new Synapse(); // Recreate synapse with mocked WSS
+      synapse.handleUpgrade(mockReq, mockSocket, mockHead);
+
+      expect(mockHandleUpgrade).toHaveBeenCalledWith(
+        mockReq,
+        mockSocket,
+        mockHead,
+        expect.any(Function),
+      );
+
+      expect(mockEmit).toHaveBeenCalledWith("connection", mockWs, mockReq);
+    });
+
+    it("should set up event handlers after successful upgrade", () => {
+      const mockReq = {} as IncomingMessage;
+      const mockSocket = {} as Socket;
+      const mockHead = Buffer.alloc(0);
+
+      const mockWs = {
+        on: jest.fn(),
+        onmessage: null as unknown as (event: WebSocket.MessageEvent) => void,
+        onclose: null as unknown as (event: WebSocket.CloseEvent) => void,
+        onerror: null as unknown as (event: WebSocket.ErrorEvent) => void,
+        readyState: WebSocket.OPEN,
+        send: jest.fn(),
+      } as unknown as WebSocket;
+
+      const mockHandleUpgrade = jest.fn((req, socket, head, cb) => {
+        cb(mockWs);
+      });
+      const mockEmit = jest.fn((event: string, ws: WebSocket) => {
+        if (event === "connection") {
+          // Simulate the WebSocketServer connection event handler
+          const connectionHandler = (mockWss.on as jest.Mock).mock.calls.find(
+            ([eventName]: [string]) => eventName === "connection",
+          )?.[1];
+          connectionHandler?.(ws);
+        }
+      });
+
+      const mockWss = {
+        handleUpgrade: mockHandleUpgrade,
+        emit: mockEmit,
+        on: jest.fn(),
+      } as unknown as WebSocketServer;
+
+      jest.mocked(WebSocketServer).mockImplementation(() => mockWss);
+
+      const onOpenMock = jest.fn();
+      const onCloseMock = jest.fn();
+      const onErrorMock = jest.fn();
+
+      synapse = new Synapse(); // Recreate synapse with mocked WSS
+      synapse.onOpen(onOpenMock);
+      synapse.onClose(onCloseMock);
+      synapse.onError(onErrorMock);
+
+      synapse.handleUpgrade(mockReq, mockSocket, mockHead);
+
+      // The onOpen callback should be triggered when the connection is established
+      expect(onOpenMock).toHaveBeenCalled();
+
+      mockWs.onclose!({} as WebSocket.CloseEvent);
+      expect(onCloseMock).toHaveBeenCalled();
+
+      mockWs.onerror!({} as WebSocket.ErrorEvent);
+      expect(onErrorMock).toHaveBeenCalledWith(
+        new Error("WebSocket error occurred"),
       );
     });
   });

--- a/tests/synapse.test.ts
+++ b/tests/synapse.test.ts
@@ -58,7 +58,9 @@ describe("Synapse", () => {
         error: new Error("Connection failed"),
       } as WebSocket.ErrorEvent);
 
-      await expect(connectPromise).rejects.toThrow("WebSocket error occurred");
+      await expect(connectPromise).rejects.toThrow(
+        "WebSocket error: Unknown error. Failed to connect to ws://localhost:8080/terminal",
+      );
     });
   });
 
@@ -269,7 +271,9 @@ describe("Synapse", () => {
 
       mockWs.onerror!({} as WebSocket.ErrorEvent);
       expect(onErrorMock).toHaveBeenCalledWith(
-        new Error("WebSocket error occurred"),
+        new Error(
+          "WebSocket error: Unknown error. Connection to localhost:3000 failed.",
+        ),
       );
     });
   });

--- a/tests/synapse.test.ts
+++ b/tests/synapse.test.ts
@@ -5,6 +5,15 @@ import { Synapse } from "../src/synapse";
 
 jest.mock("ws");
 
+const createMockWebSocket = (options: { readyState?: number } = {}) => ({
+  onopen: null as unknown as (event: WebSocket.Event) => void,
+  onmessage: null as unknown as (event: WebSocket.MessageEvent) => void,
+  onerror: null as unknown as (event: WebSocket.ErrorEvent) => void,
+  onclose: null as unknown as (event: WebSocket.CloseEvent) => void,
+  readyState: options.readyState ?? WebSocket.OPEN,
+  send: jest.fn(),
+});
+
 describe("Synapse", () => {
   let synapse: Synapse;
 
@@ -15,14 +24,7 @@ describe("Synapse", () => {
 
   describe("connect", () => {
     it("should establish websocket connection successfully", async () => {
-      const mockWs = {
-        onopen: null as unknown as (event: WebSocket.Event) => void,
-        onmessage: null as unknown as (event: WebSocket.MessageEvent) => void,
-        onerror: null as unknown as (event: WebSocket.ErrorEvent) => void,
-        onclose: null as unknown as (event: WebSocket.CloseEvent) => void,
-        readyState: WebSocket.OPEN,
-        send: jest.fn(),
-      };
+      const mockWs = createMockWebSocket();
 
       (WebSocket as unknown as jest.Mock).mockImplementation(() => mockWs);
 
@@ -35,14 +37,7 @@ describe("Synapse", () => {
 
     it("should use default host and port when not provided", async () => {
       const defaultSynapse = new Synapse();
-      const mockWs = {
-        onopen: null as unknown as (event: WebSocket.Event) => void,
-        onmessage: null as unknown as (event: WebSocket.MessageEvent) => void,
-        onerror: null as unknown as (event: WebSocket.ErrorEvent) => void,
-        onclose: null as unknown as (event: WebSocket.CloseEvent) => void,
-        readyState: WebSocket.OPEN,
-        send: jest.fn(),
-      };
+      const mockWs = createMockWebSocket();
 
       (WebSocket as unknown as jest.Mock).mockImplementation(() => mockWs);
 
@@ -54,12 +49,7 @@ describe("Synapse", () => {
     });
 
     it("should reject on connection error", async () => {
-      const mockWs = {
-        onopen: null as unknown as (event: WebSocket.Event) => void,
-        onmessage: null as unknown as (event: WebSocket.MessageEvent) => void,
-        onerror: null as unknown as (event: WebSocket.ErrorEvent) => void,
-        onclose: null as unknown as (event: WebSocket.CloseEvent) => void,
-      };
+      const mockWs = createMockWebSocket();
 
       (WebSocket as unknown as jest.Mock).mockImplementation(() => mockWs);
 
@@ -77,14 +67,7 @@ describe("Synapse", () => {
       const handler = jest.fn();
       synapse.onMessageType("test", handler);
 
-      const mockWs = {
-        onopen: null as unknown as (event: WebSocket.Event) => void,
-        onmessage: null as unknown as (event: WebSocket.MessageEvent) => void,
-        onerror: null as unknown as (event: WebSocket.ErrorEvent) => void,
-        onclose: null as unknown as (event: WebSocket.CloseEvent) => void,
-        readyState: WebSocket.OPEN,
-        send: jest.fn(),
-      };
+      const mockWs = createMockWebSocket();
 
       (WebSocket as unknown as jest.Mock).mockImplementation(() => mockWs);
       const connectPromise = synapse.connect("/terminal");
@@ -116,14 +99,7 @@ describe("Synapse", () => {
       synapse.onMessageType("test", testHandler);
       synapse.onMessageType("other", otherHandler);
 
-      const mockWs = {
-        onopen: null as unknown as (event: WebSocket.Event) => void,
-        onmessage: null as unknown as (event: WebSocket.MessageEvent) => void,
-        onerror: null as unknown as (event: WebSocket.ErrorEvent) => void,
-        onclose: null as unknown as (event: WebSocket.CloseEvent) => void,
-        readyState: WebSocket.OPEN,
-        send: jest.fn(),
-      };
+      const mockWs = createMockWebSocket();
 
       (WebSocket as unknown as jest.Mock).mockImplementation(() => mockWs);
       const connectPromise = synapse.connect("/terminal");
@@ -143,14 +119,7 @@ describe("Synapse", () => {
       const handler = jest.fn();
       synapse.onMessageType("test", handler);
 
-      const mockWs = {
-        onopen: null as unknown as (event: WebSocket.Event) => void,
-        onmessage: null as unknown as (event: WebSocket.MessageEvent) => void,
-        onerror: null as unknown as (event: WebSocket.ErrorEvent) => void,
-        onclose: null as unknown as (event: WebSocket.CloseEvent) => void,
-        readyState: WebSocket.OPEN,
-        send: jest.fn(),
-      };
+      const mockWs = createMockWebSocket();
 
       (WebSocket as unknown as jest.Mock).mockImplementation(() => mockWs);
       const connectPromise = synapse.connect("/terminal");
@@ -167,14 +136,7 @@ describe("Synapse", () => {
 
   describe("send", () => {
     it("should send messages with correct format and return promise with message payload", async () => {
-      const mockWs = {
-        onopen: null as unknown as (event: WebSocket.Event) => void,
-        onmessage: null as unknown as (event: WebSocket.MessageEvent) => void,
-        onerror: null as unknown as (event: WebSocket.ErrorEvent) => void,
-        onclose: null as unknown as (event: WebSocket.CloseEvent) => void,
-        readyState: WebSocket.OPEN,
-        send: jest.fn(),
-      };
+      const mockWs = createMockWebSocket();
 
       (WebSocket as unknown as jest.Mock).mockImplementation(() => mockWs);
       const connectPromise = synapse.connect("/terminal");
@@ -205,14 +167,7 @@ describe("Synapse", () => {
     });
 
     it("should throw error when WebSocket is not in OPEN state", async () => {
-      const mockWs = {
-        onopen: null as unknown as (event: WebSocket.Event) => void,
-        onmessage: null as unknown as (event: WebSocket.MessageEvent) => void,
-        onerror: null as unknown as (event: WebSocket.ErrorEvent) => void,
-        onclose: null as unknown as (event: WebSocket.CloseEvent) => void,
-        readyState: WebSocket.CLOSED,
-        send: jest.fn(),
-      };
+      const mockWs = createMockWebSocket({ readyState: WebSocket.CLOSED });
 
       (WebSocket as unknown as jest.Mock).mockImplementation(() => mockWs);
       const connectPromise = synapse.connect("/terminal");
@@ -235,14 +190,7 @@ describe("Synapse", () => {
 
       const mockSocket = {} as Socket;
       const mockHead = Buffer.alloc(0);
-      const mockWs = {
-        on: jest.fn(),
-        onmessage: null as unknown as (event: WebSocket.MessageEvent) => void,
-        onclose: null as unknown as (event: WebSocket.CloseEvent) => void,
-        onerror: null as unknown as (event: WebSocket.ErrorEvent) => void,
-        readyState: WebSocket.OPEN,
-        send: jest.fn(),
-      } as unknown as WebSocket;
+      const mockWs = createMockWebSocket();
 
       const mockHandleUpgrade = jest.fn((req, socket, head, cb) => {
         cb(mockWs);
@@ -279,14 +227,7 @@ describe("Synapse", () => {
       const mockSocket = {} as Socket;
       const mockHead = Buffer.alloc(0);
 
-      const mockWs = {
-        on: jest.fn(),
-        onmessage: null as unknown as (event: WebSocket.MessageEvent) => void,
-        onclose: null as unknown as (event: WebSocket.CloseEvent) => void,
-        onerror: null as unknown as (event: WebSocket.ErrorEvent) => void,
-        readyState: WebSocket.OPEN,
-        send: jest.fn(),
-      } as unknown as WebSocket;
+      const mockWs = createMockWebSocket();
 
       const mockHandleUpgrade = jest.fn((req, socket, head, cb) => {
         cb(mockWs);

--- a/tests/synapse.test.ts
+++ b/tests/synapse.test.ts
@@ -51,11 +51,11 @@ describe("Synapse", () => {
 
       (WebSocket as unknown as jest.Mock).mockImplementation(() => mockWs);
 
-      const connectPromise = defaultSynapse.connect("/terminal");
+      const connectPromise = defaultSynapse.connect("/");
       mockWs.onopen!({} as WebSocket.Event);
 
       await expect(connectPromise).resolves.toBe(defaultSynapse);
-      expect(WebSocket).toHaveBeenCalledWith("ws://localhost:3000/terminal");
+      expect(WebSocket).toHaveBeenCalledWith("ws://localhost:3000/");
     });
 
     it("should reject on connection error", async () => {
@@ -63,14 +63,32 @@ describe("Synapse", () => {
 
       (WebSocket as unknown as jest.Mock).mockImplementation(() => mockWs);
 
-      const connectPromise = synapse.connect("/terminal");
+      const connectPromise = synapse.connect("/");
       mockWs.onerror!({
         error: new Error("Connection failed"),
       } as WebSocket.ErrorEvent);
 
       await expect(connectPromise).rejects.toThrow(
-        "WebSocket error: Unknown error. Failed to connect to ws://localhost:8080/terminal",
+        "WebSocket error: Unknown error. Failed to connect to ws://localhost:8080/",
       );
+    });
+  });
+
+  describe("ping-pong", () => {
+    it("should handle ping-pong messages correctly", async () => {
+      const mockWs = createMockWebSocket();
+
+      (WebSocket as unknown as jest.Mock).mockImplementation(() => mockWs);
+
+      const connectPromise = synapse.connect("/");
+      mockWs.onopen!({} as WebSocket.Event);
+      await connectPromise;
+
+      mockWs.onmessage!({
+        data: "ping",
+      } as WebSocket.MessageEvent);
+
+      expect(mockWs.send).toHaveBeenCalledWith("pong");
     });
   });
 
@@ -82,7 +100,7 @@ describe("Synapse", () => {
       const mockWs = createMockWebSocket();
 
       (WebSocket as unknown as jest.Mock).mockImplementation(() => mockWs);
-      const connectPromise = synapse.connect("/terminal");
+      const connectPromise = synapse.connect("/");
       mockWs.onopen!({} as WebSocket.Event);
       await connectPromise;
 
@@ -114,7 +132,7 @@ describe("Synapse", () => {
       const mockWs = createMockWebSocket();
 
       (WebSocket as unknown as jest.Mock).mockImplementation(() => mockWs);
-      const connectPromise = synapse.connect("/terminal");
+      const connectPromise = synapse.connect("/");
       mockWs.onopen!({} as WebSocket.Event);
       await connectPromise;
 
@@ -134,7 +152,7 @@ describe("Synapse", () => {
       const mockWs = createMockWebSocket();
 
       (WebSocket as unknown as jest.Mock).mockImplementation(() => mockWs);
-      const connectPromise = synapse.connect("/terminal");
+      const connectPromise = synapse.connect("/");
       mockWs.onopen!({} as WebSocket.Event);
       await connectPromise;
 
@@ -151,7 +169,7 @@ describe("Synapse", () => {
       const mockWs = createMockWebSocket();
 
       (WebSocket as unknown as jest.Mock).mockImplementation(() => mockWs);
-      const connectPromise = synapse.connect("/terminal");
+      const connectPromise = synapse.connect("/");
       mockWs.onopen!({} as WebSocket.Event);
       await connectPromise;
 
@@ -182,7 +200,7 @@ describe("Synapse", () => {
       const mockWs = createMockWebSocket({ readyState: WebSocket.CLOSED });
 
       (WebSocket as unknown as jest.Mock).mockImplementation(() => mockWs);
-      const connectPromise = synapse.connect("/terminal");
+      const connectPromise = synapse.connect("/");
       mockWs.onopen!({} as WebSocket.Event);
       await connectPromise;
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

- Adds a websocket  server that initializes on construct, and adds a function `handleUpgrade` to switch from initial HTTP request to websocket connection.
- Modifies `connect()` function to take in url path, not the entire url.

## Test Plan

Added required tests.

## Related PRs and Issues

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.