### PR TITLE
fix: too many reconnects + filesystem watchFolder

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -20,6 +20,16 @@ module.exports = [
     },
     rules: {
       ...typescript.configs["recommended"].rules,
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/ban-ts-comment": [
+        "error",
+        {
+          tsExpectError: false,
+          tsIgnore: false,
+          tsNocheck: true,
+          tsCheck: true,
+        },
+      ],
     },
   },
 ];

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -24,10 +24,10 @@ module.exports = [
       "@typescript-eslint/ban-ts-comment": [
         "error",
         {
-          tsExpectError: false,
-          tsIgnore: false,
-          tsNocheck: true,
-          tsCheck: true,
+          "ts-expect-error": false,
+          "ts-ignore": false,
+          "ts-nocheck": true,
+          "ts-check": true,
         },
       ],
     },

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,8 +1,8 @@
-import typescript from "@typescript-eslint/eslint-plugin";
-import tsParser from "@typescript-eslint/parser";
-import globals from "globals";
+const typescript = require("@typescript-eslint/eslint-plugin");
+const tsParser = require("@typescript-eslint/parser");
+const globals = require("globals");
 
-export default [
+module.exports = [
   {
     files: ["**/*.ts", "**/*.tsx"],
     languageOptions: {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "license": "MIT",
   "dependencies": {
     "eslint": "^9.24.0",
+    "ignore": "^7.0.4",
     "node-pty": "^1.0.0",
     "prettier": "^3.5.3",
     "ws": "^8.18.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appwrite.io/synapse",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Operating system gateway for remote serverless environments",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/services/filesystem.ts
+++ b/src/services/filesystem.ts
@@ -10,14 +10,6 @@ export type FileItem = {
   isDirectory: boolean;
 };
 
-export type FileItemTree = FileItem & { children?: FileItemTree[] };
-
-export type FileItemTreeResult = {
-  success: boolean;
-  data?: FileItemTree;
-  error?: string;
-};
-
 export type FileItemResult = {
   success: boolean;
   data?: FileItem[];
@@ -282,77 +274,6 @@ export class Filesystem {
   }
 
   /**
-   * Recursively reads a directory and returns its tree structure
-   * @param dirPath - The path to the directory to read
-   * @returns Promise<FileOperationResult> containing the directory tree
-   */
-  async getFolderTree(dirPath: string): Promise<FileItemTreeResult> {
-    // Read and parse .gitignore from the root of the workspace
-    let ig: ReturnType<typeof ignore> | null = null;
-    try {
-      const gitignorePath = path.join(this.synapse.workDir, ".gitignore");
-      const gitignoreContent = await fs.readFile(gitignorePath, "utf-8");
-      ig = ignore().add(gitignoreContent);
-    } catch {
-      // If .gitignore does not exist, proceed without ignoring anything
-      ig = null;
-    }
-
-    // Helper function to recursively read directories
-    const readDirRecursive = async (
-      currentPath: string,
-    ): Promise<FileItemTree | null> => {
-      // Compute the relative path from the root for ignore matching
-      const relPath = path.relative("/", currentPath).replace(/\\/g, "/");
-      // Skip if ignored (but always include the root)
-      if (ig && relPath && ig.ignores(relPath)) {
-        return null;
-      }
-      const fullPath = path.join(this.synapse.workDir, currentPath);
-      const stat = await fs.lstat(fullPath);
-      const isDirectory = stat.isDirectory();
-      const item: FileItemTree = {
-        name: path.basename(currentPath),
-        isDirectory,
-      };
-      if (isDirectory) {
-        try {
-          const items = await fs.readdir(fullPath);
-          const children = await Promise.all(
-            items.map((child) =>
-              readDirRecursive(path.join(currentPath, child)),
-            ),
-          );
-          item.children = children.filter(Boolean) as FileItemTree[];
-        } catch {
-          item.children = [];
-        }
-      }
-      return item;
-    };
-
-    try {
-      this.log(`Reading directory tree at path: ${dirPath}`);
-      const tree = await readDirRecursive(dirPath);
-      if (!tree) {
-        return {
-          success: false,
-          error: "All files/folders are ignored by .gitignore",
-        };
-      }
-      return { success: true, data: tree };
-    } catch (error) {
-      this.log(
-        `Error reading directory tree ${dirPath}: ${error instanceof Error ? error.message : String(error)}`,
-      );
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : String(error),
-      };
-    }
-  }
-
-  /**
    * Updates the name of a folder
    * @param dirPath - The path to the folder to rename
    * @param name - The new name for the folder
@@ -440,19 +361,58 @@ export class Filesystem {
   }
 
   /**
-   * Starts watching a directory for changes and calls the callback with the updated folder structure.
-   * @param onChange - Callback to call with the result of getFolder when a change is detected
+   * Starts watching a directory for changes and calls the callback with the updated file path and content.
+   * @param onChange - Callback to call with the path and new content of the changed file
    */
-  watchWorkDir(onChange: (result: FileItemTreeResult) => void): void {
+  watchWorkDir(
+    onChange: (result: { path: string; content: string | null }) => void,
+  ): void {
     const fullPath = path.join(this.synapse.workDir);
     if (this.folderWatchers.has(fullPath)) {
       return;
     }
 
-    const watcher = fsSync.watch(fullPath, { recursive: true }, async () => {
-      const result = await this.getFolderTree("/");
-      onChange(result);
-    });
+    // Read and parse .gitignore from the root of the workspace
+    let ig: ReturnType<typeof ignore> | null = null;
+    try {
+      const gitignorePath = path.join(this.synapse.workDir, ".gitignore");
+      const gitignoreContent = fsSync.existsSync(gitignorePath)
+        ? fsSync.readFileSync(gitignorePath, "utf-8")
+        : "";
+      ig = ignore().add(gitignoreContent);
+    } catch {
+      ig = null;
+    }
+
+    const watcher = fsSync.watch(
+      fullPath,
+      { recursive: true },
+      async (eventType, filename) => {
+        if (!filename) return;
+        // filename is relative to workDir
+        // ignore always expects forward slashes
+        const relPath = filename.replace(/\\/g, "/");
+        if (ig && ig.ignores(relPath)) {
+          return; // ignore this change
+        }
+        const changedPath = path.join("/", filename); // relative to workDir
+        const absPath = path.join(this.synapse.workDir, filename);
+
+        try {
+          const stat = await fs.lstat(absPath);
+          if (stat.isFile()) {
+            const content = await fs.readFile(absPath, "utf-8");
+            onChange({ path: changedPath, content });
+          } else {
+            // It's a directory, not a file
+            onChange({ path: changedPath, content: null });
+          }
+        } catch {
+          // File might have been deleted or is inaccessible
+          onChange({ path: changedPath, content: null });
+        }
+      },
+    );
 
     this.folderWatchers.set(fullPath, watcher);
   }

--- a/src/services/filesystem.ts
+++ b/src/services/filesystem.ts
@@ -355,20 +355,16 @@ export class Filesystem {
 
   /**
    * Starts watching a directory for changes and calls the callback with the updated folder structure.
-   * @param dirPath - The directory path to watch (relative to workDir)
    * @param onChange - Callback to call with the result of getFolder when a change is detected
    */
-  watchFolder(
-    dirPath: string,
-    onChange: (result: FileOperationResult) => void,
-  ): void {
-    const fullPath = path.join(this.synapse.workDir, dirPath);
+  watchWorkDir(onChange: (result: FileOperationResult) => void): void {
+    const fullPath = path.join(this.synapse.workDir);
     if (this.folderWatchers.has(fullPath)) {
       return;
     }
 
     const watcher = fsSync.watch(fullPath, { recursive: false }, async () => {
-      const result = await this.getFolder(dirPath);
+      const result = await this.getFolder(this.synapse.workDir);
       onChange(result);
     });
 
@@ -377,10 +373,9 @@ export class Filesystem {
 
   /**
    * Stops watching a directory for changes.
-   * @param dirPath - The directory path to stop watching (relative to workDir)
    */
-  unwatchFolder(dirPath: string): void {
-    const fullPath = path.join(this.synapse.workDir, dirPath);
+  unwatchWorkDir(): void {
+    const fullPath = path.join(this.synapse.workDir);
     const watcher = this.folderWatchers.get(fullPath);
     if (watcher) {
       watcher.close();

--- a/src/services/filesystem.ts
+++ b/src/services/filesystem.ts
@@ -25,6 +25,7 @@ export class Filesystem {
    */
   constructor(synapse: Synapse) {
     this.synapse = synapse;
+    this.synapse.setFilesystem(this);
   }
 
   private log(message: string): void {

--- a/src/services/filesystem.ts
+++ b/src/services/filesystem.ts
@@ -392,7 +392,7 @@ export class Filesystem {
    */
   cleanup(): void {
     this.log("Cleaning up all folder watchers");
-    for (const [fullPath, watcher] of this.folderWatchers.entries()) {
+    for (const [, watcher] of this.folderWatchers.entries()) {
       watcher.close();
     }
     this.folderWatchers.clear();

--- a/src/services/filesystem.ts
+++ b/src/services/filesystem.ts
@@ -364,7 +364,7 @@ export class Filesystem {
     }
 
     const watcher = fsSync.watch(fullPath, { recursive: false }, async () => {
-      const result = await this.getFolder(this.synapse.workDir);
+      const result = await this.getFolder("/");
       onChange(result);
     });
 

--- a/src/synapse.ts
+++ b/src/synapse.ts
@@ -500,26 +500,6 @@ class Synapse {
    * @param head - The first packet of the upgraded stream
    */
   handleUpgrade(req: IncomingMessage, socket: Socket, head: Buffer): void {
-    let params: Record<string, string> | null = null;
-    let path = "/";
-
-    if (req.url) {
-      path = req.url.split("?")[0];
-      const query = req.url.split("?")[1];
-      if (query) {
-        try {
-          params = JSON.parse(query);
-        } catch {
-          params = Object.fromEntries(
-            query.split("&").map((kv) => {
-              const [k, v] = kv.split("=");
-              return [decodeURIComponent(k), decodeURIComponent(v ?? "")];
-            }),
-          );
-        }
-      }
-    }
-
     this.wss.handleUpgrade(req, socket, head, (ws: WebSocket) => {
       this.wss.emit("connection", ws, req);
     });

--- a/src/synapse.ts
+++ b/src/synapse.ts
@@ -128,7 +128,12 @@ class Synapse {
         event.reason,
         event.wasClean,
       );
-      this.attemptReconnect(connectionId);
+
+      if (!event.wasClean) {
+        this.attemptReconnect(connectionId);
+      } else {
+        this.connections.delete(connectionId);
+      }
     };
 
     ws.onerror = (error) => {

--- a/src/synapse.ts
+++ b/src/synapse.ts
@@ -119,6 +119,10 @@ class Synapse {
       reconnectAttempts: 0,
     });
 
+    ws.on("ping", () => {
+      ws.pong();
+    });
+
     ws.onmessage = (event) => this.handleMessage(event, connectionId);
 
     ws.onclose = (event) => {
@@ -203,12 +207,13 @@ class Synapse {
 
       if (!connection) return;
 
-      if (data === "ping" && connection.ws) {
-        connection.ws.send("pong");
+      let message: MessagePayload;
+      if (typeof data === "string") {
+        message = JSON.parse(data);
+      } else {
+        this.log(`Received binary data from connection ${connectionId}`);
         return;
       }
-
-      const message: MessagePayload = JSON.parse(data);
 
       if (this.messageHandlers[message.type]) {
         this.messageHandlers[message.type](message, connectionId);

--- a/tests/services/filesystem.test.ts
+++ b/tests/services/filesystem.test.ts
@@ -20,6 +20,7 @@ describe("Filesystem", () => {
     mockSynapse = jest.mocked({
       logger: jest.fn(),
       workDir: "/test",
+      setFilesystem: jest.fn(),
     } as unknown as Synapse);
 
     filesystem = new Filesystem(mockSynapse);
@@ -145,11 +146,11 @@ describe("Filesystem", () => {
       const onChangeMock = jest.fn();
 
       // Call the method being tested
-      filesystem.watchFolder(dirPath, onChangeMock);
+      filesystem.watchWorkDir(onChangeMock);
 
       // Verify watch was called with correct path
       expect(fsSync.watch).toHaveBeenCalledWith(
-        "/test/test-dir",
+        mockSynapse.workDir,
         { recursive: false },
         expect.any(Function),
       );
@@ -161,14 +162,14 @@ describe("Filesystem", () => {
       }
 
       // Verify our onChange callback was called with the result of getFolder
-      expect(filesystem.getFolder).toHaveBeenCalledWith(dirPath);
+      expect(filesystem.getFolder).toHaveBeenCalledWith(mockSynapse.workDir);
       expect(onChangeMock).toHaveBeenCalledWith({
         success: true,
         data: fileItems,
       });
 
       // Also test unwatchFolder
-      filesystem.unwatchFolder(dirPath);
+      filesystem.unwatchWorkDir();
       expect(mockWatcher.close).toHaveBeenCalled();
     });
   });

--- a/tests/services/filesystem.test.ts
+++ b/tests/services/filesystem.test.ts
@@ -111,7 +111,6 @@ describe("Filesystem", () => {
 
   describe("watchFolder", () => {
     it("should set up a watcher and call callback on file changes", async () => {
-      const dirPath = "/test-dir";
       const mockWatcher = {
         close: jest.fn(),
       };
@@ -150,7 +149,7 @@ describe("Filesystem", () => {
 
       // Verify watch was called with correct path
       expect(fsSync.watch).toHaveBeenCalledWith(
-        mockSynapse.workDir,
+        mockSynapse.workDir, // even tho path is "/", method will be called workDir + path
         { recursive: false },
         expect.any(Function),
       );
@@ -162,7 +161,7 @@ describe("Filesystem", () => {
       }
 
       // Verify our onChange callback was called with the result of getFolder
-      expect(filesystem.getFolder).toHaveBeenCalledWith(mockSynapse.workDir);
+      expect(filesystem.getFolder).toHaveBeenCalledWith("/");
       expect(onChangeMock).toHaveBeenCalledWith({
         success: true,
         data: fileItems,

--- a/tests/synapse.test.ts
+++ b/tests/synapse.test.ts
@@ -76,7 +76,7 @@ describe("Synapse", () => {
 
       // Simulate close event
       const closeEvent = { code: 4001, reason: "Test reason", wasClean: true };
-      mockWs.onclose && mockWs.onclose(closeEvent as any);
+      if (mockWs.onclose) mockWs.onclose(closeEvent as any);
 
       expect(onCloseMock).toHaveBeenCalledWith(
         "conn1",

--- a/tests/synapse.test.ts
+++ b/tests/synapse.test.ts
@@ -13,6 +13,7 @@ const createMockWebSocket = (options: { readyState?: number } = {}) => ({
   readyState: options.readyState ?? WebSocket.OPEN,
   send: jest.fn(),
   close: jest.fn(),
+  on: jest.fn(),
 });
 
 describe("Synapse", () => {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

1. removes reconnecting logic
2. add watchWorkDir to watch file changes done by terminal, returns a filetree view instead of just a layer of fileitems[]
3. use ws.ping instead of using direct messages
 
## Test Plan

add relevant tests.

## Related PRs and Issues

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes.