### PR TITLE
chore: shift workDir to be instance based

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appwrite.io/synapse",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Operating system gateway for remote serverless environments",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/services/filesystem.ts
+++ b/src/services/filesystem.ts
@@ -402,7 +402,7 @@ export class Filesystem {
   watchWorkDir(
     onChange: (result: { path: string; content: string | null }) => void,
   ): void {
-    const fullPath = this.resolvePath("");
+    const fullPath = this.resolvePath(this.workDir);
     if (this.folderWatchers.has(fullPath)) {
       return;
     }
@@ -456,7 +456,7 @@ export class Filesystem {
    * Stops watching a directory for changes.
    */
   unwatchWorkDir(): void {
-    const fullPath = this.resolvePath("");
+    const fullPath = this.resolvePath(this.workDir);
     const watcher = this.folderWatchers.get(fullPath);
     if (watcher) {
       watcher.close();

--- a/src/services/git.ts
+++ b/src/services/git.ts
@@ -11,13 +11,15 @@ export type GitOperationResult = {
 
 export class Git {
   private synapse: Synapse;
+  private workDir: string;
 
   /**
    * Creates a new Git instance
    * @param synapse - The Synapse instance to use
    */
-  constructor(synapse: Synapse) {
+  constructor(synapse: Synapse, workDir?: string) {
     this.synapse = synapse;
+    this.workDir = workDir ?? process.cwd();
   }
 
   private isErrnoException(error: unknown): error is NodeJS.ErrnoException {
@@ -26,7 +28,7 @@ export class Git {
 
   private async execute(args: string[]): Promise<GitOperationResult> {
     return new Promise((resolve) => {
-      const git = spawn("git", args, { cwd: this.synapse.workDir });
+      const git = spawn("git", args, { cwd: this.workDir });
       let output = "";
       let errorOutput = "";
 
@@ -60,7 +62,7 @@ export class Git {
 
   private async isGitRepository(): Promise<boolean> {
     try {
-      const gitDir = path.join(this.synapse.workDir, ".git");
+      const gitDir = path.join(this.workDir, ".git");
       return fs.existsSync(gitDir) && fs.statSync(gitDir).isDirectory();
     } catch (error: unknown) {
       if (this.isErrnoException(error)) {
@@ -86,7 +88,7 @@ export class Git {
 
       // Check if we have write permissions in the current directory
       try {
-        await fs.promises.access(this.synapse.workDir, fs.constants.W_OK);
+        await fs.promises.access(this.workDir, fs.constants.W_OK);
       } catch (error: unknown) {
         if (this.isErrnoException(error)) {
           return {

--- a/src/services/terminal.ts
+++ b/src/services/terminal.ts
@@ -6,6 +6,7 @@ export type TerminalOptions = {
   shell: string;
   cols?: number;
   rows?: number;
+  workDir?: string;
 };
 
 export class Terminal {
@@ -27,6 +28,7 @@ export class Terminal {
       shell: os.platform() === "win32" ? "powershell.exe" : "bash",
       cols: 80,
       rows: 24,
+      workDir: process.cwd(),
     },
   ) {
     this.synapse = synapse;
@@ -37,7 +39,7 @@ export class Terminal {
         name: "xterm-color",
         cols: terminalOptions.cols,
         rows: terminalOptions.rows,
-        cwd: this.synapse.workDir,
+        cwd: terminalOptions.workDir,
         env: process.env,
       });
 

--- a/src/synapse.ts
+++ b/src/synapse.ts
@@ -1,4 +1,3 @@
-import fs from "fs";
 import { IncomingMessage } from "http";
 import { Socket } from "net";
 import WebSocket, { WebSocketServer } from "ws";
@@ -52,22 +51,11 @@ class Synapse {
   private host: string;
   private port: number;
 
-  public workDir: string;
-
   private serverConnectionListener: ServerConnectionCallback = () => {};
 
-  constructor(
-    host: string = "localhost",
-    port: number = 3000,
-    workDir: string = process.cwd(),
-  ) {
+  constructor(host: string = "localhost", port: number = 3000) {
     this.host = host;
     this.port = port;
-
-    if (!fs.existsSync(workDir)) {
-      fs.mkdirSync(workDir, { recursive: true });
-    }
-    this.workDir = workDir;
 
     this.wss = new WebSocketServer({ noServer: true });
     this.wss.on("connection", (ws: WebSocket, req: IncomingMessage) => {
@@ -200,40 +188,6 @@ class Synapse {
    */
   setFilesystem(filesystem: Filesystem): void {
     this.filesystem = filesystem;
-  }
-
-  /**
-   * Sets the working directory for the Synapse instance
-   * @param workDir - The path to the working directory
-   * @returns void
-   */
-  updateWorkDir(workDir: string): { success: boolean; data: string } {
-    if (!fs.existsSync(workDir)) {
-      try {
-        fs.mkdirSync(workDir, { recursive: true });
-      } catch (error) {
-        const errorMessage =
-          error instanceof Error
-            ? error.message
-            : "Unknown error creating directory";
-        this.log(`Failed to create work directory: ${errorMessage}`);
-        return {
-          success: false,
-          data: `Failed to create work directory: ${errorMessage}`,
-        };
-      }
-    }
-
-    this.workDir = workDir;
-    this.terminals.forEach((terminal) => {
-      if (terminal.isTerminalAlive()) {
-        terminal.updateWorkDir(workDir);
-      }
-    });
-    return {
-      success: true,
-      data: "Work directory updated successfully",
-    };
   }
 
   /**

--- a/tests/services/filesystem.test.ts
+++ b/tests/services/filesystem.test.ts
@@ -27,7 +27,7 @@ describe("Filesystem", () => {
       setFilesystem: jest.fn(),
     } as unknown as Synapse);
 
-    filesystem = new Filesystem(mockSynapse);
+    filesystem = new Filesystem(mockSynapse, "/test");
     jest.clearAllMocks();
   });
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

`workDir` should be instance based, i.e per new connection thats created with the websocket.
but synapse is only initialized once in the codebase, creating the initial websocket connection. hence this PR shifts `workDir` to be updated with each instance.

previously on each new connection `synapse.updateWorkDir` would update the workDir across ALL terminals.

## Test Plan

## Related PRs and Issues

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes.