### PR TITLE
feat: switch to chokidar for file watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "chokidar": "^4.0.3",
     "eslint": "^9.24.0",
     "ignore": "^7.0.4",
     "node-pty": "^1.0.0",

--- a/src/services/filesystem.ts
+++ b/src/services/filesystem.ts
@@ -444,7 +444,9 @@ export class Filesystem {
     const watcher = chokidar.watch(fullPath, {
       ignored: (filePath: string) => {
         if (ig) {
-          const relativePath = filePath.replace(/\\/g, "/");
+          const relativePath = path
+            .relative(fullPath, filePath)
+            .replace(/\\/g, "/");
           if (relativePath === "") {
             return false;
           }
@@ -462,6 +464,8 @@ export class Filesystem {
       .on("all", async (event, filePath) => {
         const relativePath = path.relative(fullPath, filePath);
         const changedPath = path.join("/", relativePath);
+
+        this.log(`Event: ${event}, filePath: ${filePath}`);
 
         try {
           const stat = await fs.lstat(filePath);

--- a/src/services/filesystem.ts
+++ b/src/services/filesystem.ts
@@ -444,11 +444,9 @@ export class Filesystem {
     const watcher = chokidar.watch(fullPath, {
       ignored: (filePath: string) => {
         if (ig) {
-          const relativePath = path
-            .relative(fullPath, filePath)
-            .replace(/\\/g, "/");
+          const relativePath = filePath.replace(/\\/g, "/");
           if (relativePath === "") {
-            return true;
+            return false;
           }
           if (ig.ignores(relativePath)) {
             this.log(`Ignoring file: ${relativePath}, filePath: ${filePath}`);

--- a/src/services/filesystem.ts
+++ b/src/services/filesystem.ts
@@ -450,7 +450,10 @@ export class Filesystem {
           if (relativePath === "") {
             return true;
           }
-          return ig.ignores(relativePath);
+          if (ig.ignores(relativePath)) {
+            this.log(`Ignoring file: ${relativePath}, filePath: ${filePath}`);
+            return true;
+          }
         }
         return false;
       },

--- a/src/services/filesystem.ts
+++ b/src/services/filesystem.ts
@@ -438,8 +438,6 @@ export class Filesystem {
 
     // Initialize chokidar watcher
     const watcher = chokidar.watch(fullPath, {
-      persistent: true,
-      ignoreInitial: true,
       ignored: (filePath: string) => {
         if (ig) {
           const relativePath = path
@@ -451,10 +449,6 @@ export class Filesystem {
           return ig.ignores(relativePath);
         }
         return false;
-      },
-      awaitWriteFinish: {
-        stabilityThreshold: 300,
-        pollInterval: 100,
       },
     });
 

--- a/src/services/filesystem.ts
+++ b/src/services/filesystem.ts
@@ -445,9 +445,9 @@ export class Filesystem {
       ignored: (filePath: string) => {
         if (ig) {
           const relativePath = path
-            .relative(fullPath, filePath)
+            .relative(path.resolve(fullPath), path.resolve(filePath))
             .replace(/\\/g, "/");
-          if (relativePath === "") {
+          if (relativePath === "" || relativePath === ".") {
             return false;
           }
           if (ig.ignores(relativePath)) {
@@ -465,14 +465,14 @@ export class Filesystem {
         const relativePath = path.relative(fullPath, filePath);
         const changedPath = path.join("/", relativePath);
 
-        this.log(`Event: ${event}, filePath: ${filePath}`);
-
         try {
           const stat = await fs.lstat(filePath);
           if (stat.isFile()) {
             const content = await fs.readFile(filePath, "utf-8");
+            this.log(`Event: ${event}, filePath: ${changedPath}`);
             onChange({ path: changedPath, event, content });
           } else {
+            this.log(`Event: ${event}, filePath: ${changedPath}`);
             onChange({ path: changedPath, event, content: null });
           }
         } catch {

--- a/src/services/filesystem.ts
+++ b/src/services/filesystem.ts
@@ -442,7 +442,8 @@ export class Filesystem {
       ignoreInitial: true,
       ignored: (filePath: string) => {
         if (ig) {
-          return ig.ignores(filePath);
+          const relativePath = path.relative(fullPath, filePath).replace(/\\/g, "/");
+          return ig.ignores(relativePath);
         }
         return false;
       },

--- a/src/services/filesystem.ts
+++ b/src/services/filesystem.ts
@@ -442,7 +442,12 @@ export class Filesystem {
       ignoreInitial: true,
       ignored: (filePath: string) => {
         if (ig) {
-          const relativePath = path.relative(fullPath, filePath).replace(/\\/g, "/");
+          const relativePath = path
+            .relative(fullPath, filePath)
+            .replace(/\\/g, "/");
+          if (relativePath === "") {
+            return true;
+          }
           return ig.ignores(relativePath);
         }
         return false;

--- a/src/services/filesystem.ts
+++ b/src/services/filesystem.ts
@@ -450,6 +450,9 @@ export class Filesystem {
           if (relativePath === "" || relativePath === ".") {
             return false;
           }
+          if (relativePath.startsWith("..")) {
+            return true;
+          }
           if (ig.ignores(relativePath)) {
             this.log(`Ignoring file: ${relativePath}, filePath: ${filePath}`);
             return true;

--- a/tests/services/filesystem.test.ts
+++ b/tests/services/filesystem.test.ts
@@ -1,21 +1,14 @@
+import * as chokidar from "chokidar";
 import * as fs from "fs";
 import * as fsp from "fs/promises";
-import ignore from "ignore";
 import * as path from "path";
 import { Filesystem } from "../../src/services/filesystem";
 import { Synapse } from "../../src/synapse";
 
 jest.mock("fs/promises");
-jest.mock("fs", () => ({
-  ...jest.requireActual("fs"),
-  watch: jest.fn(),
-  existsSync: jest.fn(),
-  readFileSync: jest.fn(),
-  constants: {
-    F_OK: 0,
-  },
-}));
+jest.mock("fs");
 jest.mock("ignore");
+jest.mock("chokidar");
 
 describe("Filesystem", () => {
   let filesystem: Filesystem;
@@ -126,83 +119,6 @@ describe("Filesystem", () => {
     });
   });
 
-  describe("watchFolder", () => {
-    it("should set up a watcher and call callback on file changes, respecting .gitignore", async () => {
-      const mockWatcher = {
-        close: jest.fn(),
-      };
-
-      // Mock the filesystem functions
-      (fs.watch as jest.Mock).mockReturnValue(mockWatcher);
-      (fs.existsSync as jest.Mock).mockReturnValue(true);
-      (fs.readFileSync as jest.Mock).mockReturnValue("*.env\nnode_modules/");
-
-      // Mock ignore implementation
-      const mockIgnore = {
-        add: jest.fn().mockReturnThis(),
-        ignores: jest.fn().mockImplementation((path) => path.includes(".env")),
-      };
-      (ignore as unknown as jest.Mock).mockReturnValue(mockIgnore);
-
-      // Create a spy implementation to capture the watch callback
-      let watchCallback:
-        | ((eventType: string, filename: string) => void)
-        | null = null;
-      (fs.watch as jest.Mock).mockImplementation((path, options, callback) => {
-        watchCallback = callback;
-        return mockWatcher;
-      });
-
-      // Mock fs.lstat and fs.readFile for the file change event
-      (fsp.lstat as unknown as jest.Mock).mockResolvedValue({
-        isFile: jest.fn().mockReturnValue(true),
-      });
-      (fsp.readFile as unknown as jest.Mock).mockResolvedValue("file content");
-
-      // Set up the callback spy
-      const onChangeMock = jest.fn();
-
-      // Call the method being tested
-      filesystem.watchWorkDir(onChangeMock);
-
-      // Verify watch was called with correct path
-      expect(fs.watch).toHaveBeenCalledWith(
-        tempDir,
-        { recursive: true },
-        expect.any(Function),
-      );
-
-      // Simulate a file change event for a non-ignored file
-      if (watchCallback) {
-        // @ts-ignore
-        watchCallback("change", "file1.txt");
-      }
-
-      // Wait for the async callbacks to complete
-      await new Promise((resolve) => setImmediate(resolve));
-
-      // Check callback was called with correct data
-      expect(onChangeMock).toHaveBeenCalledWith({
-        path: "/file1.txt",
-        content: "file content",
-      });
-
-      // Test that ignored files don't trigger the callback
-      onChangeMock.mockClear();
-      if (watchCallback) {
-        // @ts-ignore
-        watchCallback("change", ".env");
-      }
-
-      await new Promise((resolve) => setImmediate(resolve));
-      expect(onChangeMock).not.toHaveBeenCalled();
-
-      // Also test unwatchFolder
-      filesystem.unwatchWorkDir();
-      expect(mockWatcher.close).toHaveBeenCalled();
-    });
-  });
-
   describe("appendFile", () => {
     it("should append content to a file", async () => {
       const filePath = path.join(tempDir, "file.txt");
@@ -250,6 +166,46 @@ describe("Filesystem", () => {
       // Search for non-matching term
       results = await filesystem.searchFiles("notfound");
       expect(results.data?.results).toEqual([]);
+    });
+  });
+
+  describe("watchWorkDir", () => {
+    it("should set up a watcher and handle file changes", async () => {
+      const onChange = jest.fn();
+      const testFilePath = path.join(tempDir, "watch-test.txt");
+
+      // Mock chokidar watcher
+      const mockWatcher = {
+        on: jest.fn().mockReturnThis(),
+        close: jest.fn(),
+      };
+      (chokidar.watch as jest.Mock).mockReturnValue(mockWatcher);
+
+      // Mock file system operations
+      (fsp.lstat as jest.Mock).mockResolvedValue({ isFile: () => true });
+      (fsp.readFile as jest.Mock).mockResolvedValue("test content");
+
+      // Start watching
+      filesystem.watchWorkDir(onChange);
+
+      // Simulate file change event
+      const addCallback = mockWatcher.on.mock.calls.find(
+        (call) => call[0] === "add",
+      )[1];
+      addCallback(testFilePath);
+
+      // Wait for the watcher to detect changes
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Verify onChange was called with correct data
+      expect(onChange).toHaveBeenCalledWith({
+        path: "/watch-test.txt",
+        content: "test content",
+      });
+
+      // Clean up
+      filesystem.unwatchWorkDir();
+      expect(mockWatcher.close).toHaveBeenCalled();
     });
   });
 });

--- a/tests/services/filesystem.test.ts
+++ b/tests/services/filesystem.test.ts
@@ -189,10 +189,7 @@ describe("Filesystem", () => {
       filesystem.watchWorkDir(onChange);
 
       // Simulate file change event
-      const addCallback = mockWatcher.on.mock.calls.find(
-        (call) => call[0] === "add",
-      )[1];
-      addCallback(testFilePath);
+      mockWatcher.on.mock.calls[0][1]("add", testFilePath);
 
       // Wait for the watcher to detect changes
       await new Promise((resolve) => setTimeout(resolve, 100));
@@ -200,6 +197,7 @@ describe("Filesystem", () => {
       // Verify onChange was called with correct data
       expect(onChange).toHaveBeenCalledWith({
         path: "/watch-test.txt",
+        event: "add",
         content: "test content",
       });
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Uses chokidar instead of fs.watch for better memory performance.

## Test Plan

## Related PRs and Issues

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes.