### PR TITLE
feat: add `fs.listFilesInDir` and `terminal.executeCommand` operations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appwrite.io/synapse",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@appwrite.io/synapse",
-      "version": "0.6.0",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^3.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appwrite.io/synapse",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Operating system gateway for remote serverless environments",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/services/filesystem.ts
+++ b/src/services/filesystem.ts
@@ -124,7 +124,7 @@ export class Filesystem {
    */
   async createFile(
     filePath: string,
-    content: string = ""
+    content: string = "",
   ): Promise<FileOperationResult> {
     if (!filePath) {
       return { success: false, error: "filePath is required" };
@@ -145,7 +145,7 @@ export class Filesystem {
           const folderResult = await this.createFolder(dirPath);
           if (!folderResult.success) {
             this.log(
-              `Failed to create parent directory for ${filePath}: ${folderResult.error}`
+              `Failed to create parent directory for ${filePath}: ${folderResult.error}`,
             );
 
             return { success: false, error: folderResult.error }; // failed to create parent directory
@@ -207,7 +207,7 @@ export class Filesystem {
       };
     } catch (error) {
       this.log(
-        `Error: ${error instanceof Error ? error.message : String(error)}`
+        `Error: ${error instanceof Error ? error.message : String(error)}`,
       );
       return {
         success: false,
@@ -225,7 +225,7 @@ export class Filesystem {
    */
   async updateFile(
     filePath: string,
-    content: string
+    content: string,
   ): Promise<FileOperationResult> {
     if (!filePath) {
       return { success: false, error: "filePath is required" };
@@ -242,7 +242,7 @@ export class Filesystem {
       return { success: true };
     } catch (error) {
       this.log(
-        `Error: ${error instanceof Error ? error.message : String(error)}`
+        `Error: ${error instanceof Error ? error.message : String(error)}`,
       );
       return {
         success: false,
@@ -260,7 +260,7 @@ export class Filesystem {
    */
   async appendFile(
     filePath: string,
-    content: string
+    content: string,
   ): Promise<FileOperationResult> {
     if (!filePath) {
       return { success: false, error: "filePath is required" };
@@ -272,7 +272,7 @@ export class Filesystem {
       return { success: true };
     } catch (error) {
       this.log(
-        `Error: ${error instanceof Error ? error.message : String(error)}`
+        `Error: ${error instanceof Error ? error.message : String(error)}`,
       );
       return {
         success: false,
@@ -290,7 +290,7 @@ export class Filesystem {
    */
   async updateFilePath(
     oldPath: string,
-    newPath: string
+    newPath: string,
   ): Promise<FileOperationResult> {
     if (!oldPath || !newPath) {
       return { success: false, error: "oldPath and newPath are required" };
@@ -306,7 +306,7 @@ export class Filesystem {
       return { success: true };
     } catch (error) {
       this.log(
-        `Error: ${error instanceof Error ? error.message : String(error)}`
+        `Error: ${error instanceof Error ? error.message : String(error)}`,
       );
       return {
         success: false,
@@ -335,7 +335,7 @@ export class Filesystem {
       return { success: true };
     } catch (error) {
       this.log(
-        `Error: ${error instanceof Error ? error.message : String(error)}`
+        `Error: ${error instanceof Error ? error.message : String(error)}`,
       );
       return {
         success: false,
@@ -369,7 +369,7 @@ export class Filesystem {
     } catch (error: unknown) {
       const errorMsg = error instanceof Error ? error.message : String(error);
       this.log(
-        `Error creating directory at path ${fullPath}: ${errorMsg} (Code: ${(error as NodeJS.ErrnoException)?.code})`
+        `Error creating directory at path ${fullPath}: ${errorMsg} (Code: ${(error as NodeJS.ErrnoException)?.code})`,
       );
 
       return {
@@ -403,7 +403,7 @@ export class Filesystem {
       return { success: true, data };
     } catch (error) {
       this.log(
-        `Error reading directory ${dirPath}: ${error instanceof Error ? error.message : String(error)}`
+        `Error reading directory ${dirPath}: ${error instanceof Error ? error.message : String(error)}`,
       );
       return {
         success: false,
@@ -421,7 +421,7 @@ export class Filesystem {
    */
   async updateFolderName(
     dirPath: string,
-    name: string
+    name: string,
   ): Promise<FileOperationResult> {
     if (!dirPath || !name) {
       return { success: false, error: "dirPath and name are required" };
@@ -439,7 +439,7 @@ export class Filesystem {
       return { success: true };
     } catch (error) {
       this.log(
-        `Error: ${error instanceof Error ? error.message : String(error)}`
+        `Error: ${error instanceof Error ? error.message : String(error)}`,
       );
       return {
         success: false,
@@ -457,7 +457,7 @@ export class Filesystem {
    */
   async updateFolderPath(
     oldPath: string,
-    newPath: string
+    newPath: string,
   ): Promise<FileOperationResult> {
     if (!oldPath || !newPath) {
       return { success: false, error: "oldPath and newPath are required" };
@@ -473,7 +473,7 @@ export class Filesystem {
       return { success: true };
     } catch (error) {
       this.log(
-        `Error: ${error instanceof Error ? error.message : String(error)}`
+        `Error: ${error instanceof Error ? error.message : String(error)}`,
       );
       return {
         success: false,
@@ -502,7 +502,7 @@ export class Filesystem {
       return { success: true };
     } catch (error) {
       this.log(
-        `Error: ${error instanceof Error ? error.message : String(error)}`
+        `Error: ${error instanceof Error ? error.message : String(error)}`,
       );
       return {
         success: false,
@@ -520,7 +520,7 @@ export class Filesystem {
       path: string;
       event: string;
       content: string | null;
-    }) => void
+    }) => void,
   ): void {
     const fullPath = this.resolvePath(this.workDir);
     if (this.folderWatchers.has(fullPath)) {
@@ -875,7 +875,7 @@ export class Filesystem {
           }
           if (
             [...IGNORE_PATTERNS, ...(additionalIgnorePatterns || [])].some(
-              (pattern) => relPath.includes(pattern)
+              (pattern) => relPath.includes(pattern),
             )
           ) {
             continue;
@@ -913,7 +913,7 @@ export class Filesystem {
       };
     } catch (error) {
       this.log(
-        `Error listing files in directory ${dirPath}: ${error instanceof Error ? error.message : String(error)}`
+        `Error listing files in directory ${dirPath}: ${error instanceof Error ? error.message : String(error)}`,
       );
       return {
         success: false,

--- a/src/services/filesystem.ts
+++ b/src/services/filesystem.ts
@@ -8,7 +8,14 @@ import mime from "mime-types";
 import * as path from "path";
 import { Synapse } from "../synapse";
 
-const IGNORE_PATTERNS = ["node_modules", "dist", "build", "coverage", "logs"];
+const IGNORE_PATTERNS = [
+  "node_modules",
+  "dist",
+  "build",
+  "coverage",
+  "logs",
+  ".git",
+];
 
 export type FileItem = {
   name: string;
@@ -61,9 +68,10 @@ export type ZipResult = {
   };
 };
 
-export type FileListItem<WithContent extends boolean = false> = WithContent extends true 
-  ? { path: string; content: string }
-  : { path: string };
+export type FileListItem<WithContent extends boolean = false> =
+  WithContent extends true
+    ? { path: string; content: string }
+    : { path: string };
 
 export type FileListResult<WithContent extends boolean = false> = {
   success: boolean;
@@ -116,7 +124,7 @@ export class Filesystem {
    */
   async createFile(
     filePath: string,
-    content: string = "",
+    content: string = ""
   ): Promise<FileOperationResult> {
     if (!filePath) {
       return { success: false, error: "filePath is required" };
@@ -137,7 +145,7 @@ export class Filesystem {
           const folderResult = await this.createFolder(dirPath);
           if (!folderResult.success) {
             this.log(
-              `Failed to create parent directory for ${filePath}: ${folderResult.error}`,
+              `Failed to create parent directory for ${filePath}: ${folderResult.error}`
             );
 
             return { success: false, error: folderResult.error }; // failed to create parent directory
@@ -199,7 +207,7 @@ export class Filesystem {
       };
     } catch (error) {
       this.log(
-        `Error: ${error instanceof Error ? error.message : String(error)}`,
+        `Error: ${error instanceof Error ? error.message : String(error)}`
       );
       return {
         success: false,
@@ -217,7 +225,7 @@ export class Filesystem {
    */
   async updateFile(
     filePath: string,
-    content: string,
+    content: string
   ): Promise<FileOperationResult> {
     if (!filePath) {
       return { success: false, error: "filePath is required" };
@@ -234,7 +242,7 @@ export class Filesystem {
       return { success: true };
     } catch (error) {
       this.log(
-        `Error: ${error instanceof Error ? error.message : String(error)}`,
+        `Error: ${error instanceof Error ? error.message : String(error)}`
       );
       return {
         success: false,
@@ -252,7 +260,7 @@ export class Filesystem {
    */
   async appendFile(
     filePath: string,
-    content: string,
+    content: string
   ): Promise<FileOperationResult> {
     if (!filePath) {
       return { success: false, error: "filePath is required" };
@@ -264,7 +272,7 @@ export class Filesystem {
       return { success: true };
     } catch (error) {
       this.log(
-        `Error: ${error instanceof Error ? error.message : String(error)}`,
+        `Error: ${error instanceof Error ? error.message : String(error)}`
       );
       return {
         success: false,
@@ -282,7 +290,7 @@ export class Filesystem {
    */
   async updateFilePath(
     oldPath: string,
-    newPath: string,
+    newPath: string
   ): Promise<FileOperationResult> {
     if (!oldPath || !newPath) {
       return { success: false, error: "oldPath and newPath are required" };
@@ -298,7 +306,7 @@ export class Filesystem {
       return { success: true };
     } catch (error) {
       this.log(
-        `Error: ${error instanceof Error ? error.message : String(error)}`,
+        `Error: ${error instanceof Error ? error.message : String(error)}`
       );
       return {
         success: false,
@@ -327,7 +335,7 @@ export class Filesystem {
       return { success: true };
     } catch (error) {
       this.log(
-        `Error: ${error instanceof Error ? error.message : String(error)}`,
+        `Error: ${error instanceof Error ? error.message : String(error)}`
       );
       return {
         success: false,
@@ -361,7 +369,7 @@ export class Filesystem {
     } catch (error: unknown) {
       const errorMsg = error instanceof Error ? error.message : String(error);
       this.log(
-        `Error creating directory at path ${fullPath}: ${errorMsg} (Code: ${(error as NodeJS.ErrnoException)?.code})`,
+        `Error creating directory at path ${fullPath}: ${errorMsg} (Code: ${(error as NodeJS.ErrnoException)?.code})`
       );
 
       return {
@@ -395,7 +403,7 @@ export class Filesystem {
       return { success: true, data };
     } catch (error) {
       this.log(
-        `Error reading directory ${dirPath}: ${error instanceof Error ? error.message : String(error)}`,
+        `Error reading directory ${dirPath}: ${error instanceof Error ? error.message : String(error)}`
       );
       return {
         success: false,
@@ -413,7 +421,7 @@ export class Filesystem {
    */
   async updateFolderName(
     dirPath: string,
-    name: string,
+    name: string
   ): Promise<FileOperationResult> {
     if (!dirPath || !name) {
       return { success: false, error: "dirPath and name are required" };
@@ -431,7 +439,7 @@ export class Filesystem {
       return { success: true };
     } catch (error) {
       this.log(
-        `Error: ${error instanceof Error ? error.message : String(error)}`,
+        `Error: ${error instanceof Error ? error.message : String(error)}`
       );
       return {
         success: false,
@@ -449,7 +457,7 @@ export class Filesystem {
    */
   async updateFolderPath(
     oldPath: string,
-    newPath: string,
+    newPath: string
   ): Promise<FileOperationResult> {
     if (!oldPath || !newPath) {
       return { success: false, error: "oldPath and newPath are required" };
@@ -465,7 +473,7 @@ export class Filesystem {
       return { success: true };
     } catch (error) {
       this.log(
-        `Error: ${error instanceof Error ? error.message : String(error)}`,
+        `Error: ${error instanceof Error ? error.message : String(error)}`
       );
       return {
         success: false,
@@ -494,7 +502,7 @@ export class Filesystem {
       return { success: true };
     } catch (error) {
       this.log(
-        `Error: ${error instanceof Error ? error.message : String(error)}`,
+        `Error: ${error instanceof Error ? error.message : String(error)}`
       );
       return {
         success: false,
@@ -512,7 +520,7 @@ export class Filesystem {
       path: string;
       event: string;
       content: string | null;
-    }) => void,
+    }) => void
   ): void {
     const fullPath = this.resolvePath(this.workDir);
     if (this.folderWatchers.has(fullPath)) {
@@ -817,14 +825,17 @@ export class Filesystem {
    * @param recursive - Whether to recursively traverse subdirectories
    * @returns Promise<FileListResult> containing array of file objects
    */
-  async listFilesInDir(dirPath: string, withContent: true, recursive?: boolean): Promise<FileListResult<true>>;
-  async listFilesInDir(dirPath: string, withContent?: false, recursive?: boolean): Promise<FileListResult<false>>;
-  async listFilesInDir(dirPath: string, withContent?: boolean, recursive?: boolean): Promise<FileListResult<boolean>>;
-  async listFilesInDir(
-    dirPath: string,
-    withContent: boolean = false,
-    recursive: boolean = false,
-  ): Promise<FileListResult<boolean>> {
+  async listFilesInDir({
+    dirPath,
+    withContent,
+    recursive,
+    additionalIgnorePatterns,
+  }: {
+    dirPath: string;
+    withContent?: boolean;
+    recursive?: boolean;
+    additionalIgnorePatterns?: string[];
+  }): Promise<FileListResult<boolean>> {
     if (!dirPath) {
       return { success: false, error: "path is required" };
     }
@@ -862,7 +873,11 @@ export class Filesystem {
           if (ig && ig.ignores(relPath)) {
             continue;
           }
-          if (IGNORE_PATTERNS.some((pattern) => relPath.includes(pattern))) {
+          if (
+            [...IGNORE_PATTERNS, ...(additionalIgnorePatterns || [])].some(
+              (pattern) => relPath.includes(pattern)
+            )
+          ) {
             continue;
           }
 
@@ -898,7 +913,7 @@ export class Filesystem {
       };
     } catch (error) {
       this.log(
-        `Error listing files in directory ${dirPath}: ${error instanceof Error ? error.message : String(error)}`,
+        `Error listing files in directory ${dirPath}: ${error instanceof Error ? error.message : String(error)}`
       );
       return {
         success: false,

--- a/src/services/terminal.ts
+++ b/src/services/terminal.ts
@@ -5,8 +5,6 @@ import { Synapse } from "../synapse";
 import { exec } from "child_process";
 import { promisify } from "util";
 
-const execAsync = promisify(exec);
-
 export type TerminalOptions = {
   shell: string;
   cols?: number;
@@ -151,7 +149,7 @@ export class Terminal {
     }
 
     try {
-      const { stdout, stderr } = await execAsync(command, {
+      const { stdout, stderr } = await promisify(exec)(command, {
         cwd,
         encoding: 'utf-8',
         timeout,

--- a/src/services/terminal.ts
+++ b/src/services/terminal.ts
@@ -156,7 +156,7 @@ export class Terminal {
       });
 
       return {
-        output: (stdout || stderr || '').trimEnd(),
+        output: stdout || stderr || '',
         exitCode: 0 // Success case - error case is handled in catch block
       }
     } catch (error: any) {

--- a/src/services/terminal.ts
+++ b/src/services/terminal.ts
@@ -139,7 +139,11 @@ export class Terminal {
     }
   }
 
-  async executeCommand(command: string, cwd: string, timeout: number = 5000): Promise<{ output: string, exitCode: number }> {
+  async executeCommand(
+    command: string,
+    cwd: string,
+    timeout: number = 5000,
+  ): Promise<{ output: string; exitCode: number }> {
     if (!command) {
       throw new Error("Command is required");
     }
@@ -151,14 +155,14 @@ export class Terminal {
     try {
       const { stdout, stderr } = await promisify(exec)(command, {
         cwd,
-        encoding: 'utf-8',
+        encoding: "utf-8",
         timeout,
       });
 
       return {
-        output: stdout || stderr || '',
-        exitCode: 0 // Success case - error case is handled in catch block
-      }
+        output: stdout || stderr || "",
+        exitCode: 0, // Success case - error case is handled in catch block
+      };
     } catch (error: any) {
       console.error("Failed to execute command:", error);
       return {

--- a/src/services/terminal.ts
+++ b/src/services/terminal.ts
@@ -156,7 +156,7 @@ export class Terminal {
       });
 
       return {
-        output: stdout || stderr || '',
+        output: (stdout || stderr || '').trimEnd(),
         exitCode: 0 // Success case - error case is handled in catch block
       }
     } catch (error: any) {

--- a/tests/services/filesystem.test.ts
+++ b/tests/services/filesystem.test.ts
@@ -199,29 +199,28 @@ describe("Filesystem", () => {
       };
       (chokidar.watch as jest.Mock).mockReturnValue(mockWatcher);
 
-      // Mock file system operations
-      (fsp.lstat as jest.Mock).mockResolvedValue({ isFile: () => true });
-      (fsp.readFile as jest.Mock).mockResolvedValue("test content");
+      // Mock fs.stat and fs.readFile for the file content
+      jest.spyOn(fsp, "lstat").mockResolvedValue({
+        isFile: () => true,
+        isDirectory: () => false,
+      } as any);
+      jest.spyOn(fsp, "readFile").mockResolvedValue("test content");
 
-      // Start watching
       filesystem.watchWorkDir(onChange);
 
-      // Simulate file change event
-      mockWatcher.on.mock.calls[0][1]("add", testFilePath);
+      // Simulate file change event (triggering the "all" event)
+      const onAllCallback = mockWatcher.on.mock.calls.find(
+        (call) => call[0] === "all",
+      )?.[1];
+      if (onAllCallback) {
+        await onAllCallback("change", testFilePath);
+      }
 
-      // Wait for the watcher to detect changes
-      await new Promise((resolve) => setTimeout(resolve, 100));
-
-      // Verify onChange was called with correct data
       expect(onChange).toHaveBeenCalledWith({
         path: "watch-test.txt",
-        event: "add",
+        event: "change",
         content: "test content",
       });
-
-      // Clean up
-      filesystem.unwatchWorkDir();
-      expect(mockWatcher.close).toHaveBeenCalled();
     });
   });
 
@@ -350,6 +349,122 @@ describe("Filesystem", () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe("Failed to read directory");
+    });
+  });
+
+  describe("listFilesInDir", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("should list files without content", async () => {
+      const testDir = "test-dir";
+      const mockFiles = [
+        { name: "file1.txt", isDirectory: () => false, isFile: () => true },
+        { name: "file2.js", isDirectory: () => false, isFile: () => true },
+        { name: "subdir", isDirectory: () => true, isFile: () => false },
+      ];
+
+      (fsp.readdir as jest.Mock).mockResolvedValue(mockFiles);
+      (fsSync.existsSync as jest.Mock).mockReturnValue(false); // No .gitignore
+
+      const result = await filesystem.listFilesInDir(testDir, false, false);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toHaveLength(2); // Only files, not directories
+      expect(result.data?.[0]).toEqual({ path: "test-dir/file1.txt" });
+      expect(result.data?.[1]).toEqual({ path: "test-dir/file2.js" });
+    });
+
+    it("should list files with content", async () => {
+      const testDir = "test-dir";
+      const mockFiles = [
+        { name: "file1.txt", isDirectory: () => false, isFile: () => true },
+        { name: "file2.js", isDirectory: () => false, isFile: () => true },
+      ];
+
+      (fsp.readdir as jest.Mock).mockResolvedValue(mockFiles);
+      (fsSync.existsSync as jest.Mock).mockReturnValue(false); // No .gitignore
+      (fsp.readFile as jest.Mock)
+        .mockResolvedValueOnce("content of file1")
+        .mockResolvedValueOnce("content of file2");
+
+      const result = await filesystem.listFilesInDir(testDir, true, false);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toHaveLength(2);
+      expect(result.data?.[0]).toEqual({ 
+        path: "test-dir/file1.txt", 
+        content: "content of file1" 
+      });
+      expect(result.data?.[1]).toEqual({ 
+        path: "test-dir/file2.js", 
+        content: "content of file2" 
+      });
+    });
+
+    it("should handle recursive directory traversal", async () => {
+      const testDir = "test-dir";
+      const mockRootFiles = [
+        { name: "root.txt", isDirectory: () => false, isFile: () => true },
+        { name: "subdir", isDirectory: () => true, isFile: () => false },
+      ];
+      const mockSubdirFiles = [
+        { name: "sub.txt", isDirectory: () => false, isFile: () => true },
+      ];
+
+      (fsp.readdir as jest.Mock)
+        .mockResolvedValueOnce(mockRootFiles) // First call for root dir
+        .mockResolvedValueOnce(mockSubdirFiles); // Second call for subdirectory
+
+      (fsSync.existsSync as jest.Mock).mockReturnValue(false); // No .gitignore
+
+      const result = await filesystem.listFilesInDir(testDir, false, true);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toHaveLength(2);
+      expect(result.data?.map(f => f.path)).toEqual(["test-dir/root.txt", "test-dir/subdir/sub.txt"]);
+    });
+
+    it("should handle file read errors when withContent is true", async () => {
+      const testDir = "test-dir";
+      const mockFiles = [
+        { name: "file1.txt", isDirectory: () => false, isFile: () => true },
+        { name: "file2.txt", isDirectory: () => false, isFile: () => true },
+      ];
+
+      (fsp.readdir as jest.Mock).mockResolvedValue(mockFiles);
+      (fsSync.existsSync as jest.Mock).mockReturnValue(false); // No .gitignore
+      (fsp.readFile as jest.Mock)
+        .mockResolvedValueOnce("content of file1")
+        .mockRejectedValueOnce(new Error("Permission denied")); // Second file fails
+
+      const result = await filesystem.listFilesInDir(testDir, true, false);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toHaveLength(1); // Only the readable file
+      expect(result.data?.[0]).toEqual({ 
+        path: "test-dir/file1.txt", 
+        content: "content of file1" 
+      });
+    });
+
+    it("should return error when dirPath is not provided", async () => {
+      const result = await filesystem.listFilesInDir("", false, false);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("path is required");
+    });
+
+    it("should handle directory read errors", async () => {
+      const testDir = "nonexistent-dir";
+      
+      (fsp.readdir as jest.Mock).mockRejectedValue(new Error("Directory not found"));
+
+      const result = await filesystem.listFilesInDir(testDir, false, false);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual([]);
     });
   });
 });

--- a/tests/services/terminal.test.ts
+++ b/tests/services/terminal.test.ts
@@ -4,6 +4,7 @@ import { Terminal, TerminalOptions } from "../../src/services/terminal";
 import { Synapse } from "../../src/synapse";
 
 jest.mock("node-pty");
+jest.mock("child_process");
 
 describe("Terminal", () => {
   let terminal: Terminal;
@@ -104,6 +105,54 @@ describe("Terminal", () => {
 
       const customTerminal = new Terminal(mockSynapse, customOptions);
       expect(customTerminal.isTerminalAlive()).toBe(true);
+    });
+  });
+
+  describe("executeCommand", () => {
+    beforeEach(() => {
+      terminal = new Terminal(mockSynapse);
+      jest.spyOn(fs, "existsSync").mockReturnValue(true);
+    });
+
+    it("should successfully execute a command", async () => {
+      const { exec } = require("child_process");
+      (exec as jest.Mock).mockImplementation((command, options, callback) => {
+        callback(null, { stdout: "hello\n", stderr: "" });
+      });
+
+      const result = await terminal.executeCommand("echo hello", "/tmp");
+
+      expect(result).toEqual({
+        output: "hello\n",
+        exitCode: 0,
+      });
+    });
+
+    it("should handle command execution errors", async () => {
+      const { exec } = require("child_process");
+      const mockError = new Error("Command failed: invalid-command\n/bin/sh: invalid-command: command not found\n");
+      (exec as jest.Mock).mockImplementation((command, options, callback) => {
+        callback(mockError, null);
+      });
+
+      const result = await terminal.executeCommand("invalid-command", "/tmp");
+
+      expect(result).toEqual({
+        output: "Error: Command failed: invalid-command\n/bin/sh: invalid-command: command not found\n",
+        exitCode: 1,
+      });
+    });
+
+    it("should throw error when command is not provided", async () => {
+      await expect(terminal.executeCommand("", "/tmp")).rejects.toThrow(
+        "Command is required",
+      );
+    });
+
+    it("should throw error when cwd is not provided", async () => {
+      await expect(terminal.executeCommand("echo hello", "")).rejects.toThrow(
+        "cwd is required",
+      );
     });
   });
 });

--- a/tests/services/terminal.test.ts
+++ b/tests/services/terminal.test.ts
@@ -130,7 +130,9 @@ describe("Terminal", () => {
 
     it("should handle command execution errors", async () => {
       const { exec } = require("child_process");
-      const mockError = new Error("Command failed: invalid-command\n/bin/sh: invalid-command: command not found\n");
+      const mockError = new Error(
+        "Command failed: invalid-command\n/bin/sh: invalid-command: command not found\n",
+      );
       (exec as jest.Mock).mockImplementation((command, options, callback) => {
         callback(mockError, null);
       });
@@ -138,7 +140,8 @@ describe("Terminal", () => {
       const result = await terminal.executeCommand("invalid-command", "/tmp");
 
       expect(result).toEqual({
-        output: "Error: Command failed: invalid-command\n/bin/sh: invalid-command: command not found\n",
+        output:
+          "Error: Command failed: invalid-command\n/bin/sh: invalid-command: command not found\n",
         exitCode: 1,
       });
     });


### PR DESCRIPTION
- PLA-3179
- PLA-3178

These two operations were designed to be used by the LLM gateway, NOT the Console UI.

# listFilesInDir

We need an easy way to quickly list files in a certain path.

## Parameters
- `dirPath` (string): the path to list files under
- `recursive` (boolean): whether to list the files recursively or not, `false` by default
- `withContent` (boolean) whether to include the file contents in the result or not, `false` by default

## Result
Example:

```json
[
        {
            "path": "test.txt",
            "content": "hi\n"
        },
        {
            "path": "test2.txt",
            "content": "hi\n"
        }
]
```

# executeCommand

We need an operation to execute a command, await on the output, and retrieve the output as well as exit code.

## Parameters:
- `command` (string): the command to execute
- `cwd` (string): current working directory
- `timeout` (number): timeout, defaults to 5000 ms 

## Result
Example:

```json
{
        "output": "hello world\n",
        "exitCode": 0
}
```

